### PR TITLE
Persistent token sessions, device-aware auth, and dashboard-first routing

### DIFF
--- a/assets/js/login.js
+++ b/assets/js/login.js
@@ -1,82 +1,68 @@
-import { auth, db } from './firebase-config.js';
-
 document.addEventListener('DOMContentLoaded', function() {
     const loginForm = document.getElementById('login-form');
 
-    if (loginForm) {
-        loginForm.addEventListener('submit', async function(e) {
-            e.preventDefault();
+    if (!loginForm) return;
 
-            const email = document.getElementById('login-email').value;
-            const password = document.getElementById('login-password').value;
-
-            try {
-                // Show loading state
-                const submitBtn = loginForm.querySelector('button[type="submit"]');
-                submitBtn.disabled = true;
-                submitBtn.innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Logging in...';
-
-                await handleLogin(email, password);
-            } catch (error) {
-                console.error('Login error:', error);
-                // Error handling is done in handleLogin
-            }
-        });
+    const existingSession = window.ReliefSession?.getCurrentSession?.();
+    if (existingSession?.user) {
+        window.location.href = 'dashboard.html';
+        return;
     }
+
+    loginForm.addEventListener('submit', async function(e) {
+        e.preventDefault();
+
+        const email = document.getElementById('login-email').value.trim().toLowerCase();
+        const password = document.getElementById('login-password').value;
+
+        const submitBtn = loginForm.querySelector('button[type="submit"]');
+        if (submitBtn) {
+            submitBtn.disabled = true;
+            submitBtn.textContent = 'Logging in...';
+        }
+
+        try {
+            const user = await authenticateUser(email, password);
+            window.ReliefSession?.createSession?.(user);
+            showAlert('success', 'Login successful! Redirecting to dashboard...');
+            setTimeout(() => {
+                window.location.href = 'dashboard.html';
+            }, 800);
+        } catch (error) {
+            showAlert('danger', error.message || 'Login failed. Please try again.');
+        } finally {
+            if (submitBtn) {
+                submitBtn.disabled = false;
+                submitBtn.textContent = 'Login';
+            }
+        }
+    });
 });
 
-async function handleLogin(email, password) {
-    try {
-        const userCredential = await auth.signInWithEmailAndPassword(email, password);
-        const userDoc = await db.collection('users').doc(userCredential.user.uid).get();
-
-        if (!userDoc.exists) {
-            throw new Error('User data not found. Please contact support.');
-        }
-
-        const userData = userDoc.data();
-
-        // Store user in localStorage
-        localStorage.setItem('currentUser', JSON.stringify({
-            id: userCredential.user.uid,
-            email: userCredential.user.email,
-            name: userData.name
-        }));
-
-        // Show success message
-        showAlert('success', 'Login successful! Redirecting...');
-
-        // Redirect after short delay
-        setTimeout(() => {
-            window.location.href = '../index.html';
-        }, 1500);
-
-    } catch (error) {
-        let errorMessage = 'Login failed. Please try again.';
-
-        // More specific error messages
-        if (error.code === 'auth/user-not-found') {
-            errorMessage = 'No account found with this email.';
-        } else if (error.code === 'auth/wrong-password') {
-            errorMessage = 'Incorrect password. Please try again.';
-        } else if (error.code === 'auth/too-many-requests') {
-            errorMessage = 'Account temporarily locked due to too many failed attempts.';
-        }
-
-        showAlert('danger', errorMessage);
-        console.error('Login error:', error);
-    } finally {
-        // Reset button state
-        const submitBtn = document.querySelector('#login-form button[type="submit"]');
-        if (submitBtn) {
-            submitBtn.disabled = false;
-            submitBtn.textContent = 'Login';
+async function authenticateUser(email, password) {
+    if (typeof ReliefAPI !== 'undefined' && ReliefAPI.login) {
+        try {
+            return await ReliefAPI.login(email, password);
+        } catch (error) {
+            console.warn('API login unavailable, falling back to local auth:', error);
         }
     }
+
+    const users = JSON.parse(localStorage.getItem('relief_users') || '[]');
+    const user = users.find(item => item.email === email && item.password === password);
+
+    if (!user) {
+        throw new Error('Invalid email or password.');
+    }
+
+    return {
+        uid: user.id,
+        email: user.email,
+        name: user.name
+    };
 }
 
 function showAlert(type, message) {
-    // Remove any existing alerts
     const existingAlert = document.querySelector('.alert');
     if (existingAlert) {
         existingAlert.remove();
@@ -91,7 +77,6 @@ function showAlert(type, message) {
         form.appendChild(alertDiv);
     }
 
-    // Auto-remove after 5 seconds
     setTimeout(() => {
         alertDiv.remove();
     }, 5000);

--- a/assets/js/signup.js
+++ b/assets/js/signup.js
@@ -1,97 +1,89 @@
-import { auth, db } from './firebase-config.js';
-
 document.addEventListener('DOMContentLoaded', function() {
     const signupForm = document.getElementById('signup-form');
 
-    if (signupForm) {
-        signupForm.addEventListener('submit', async function(e) {
-            e.preventDefault();
+    if (!signupForm) return;
 
-            const name = document.getElementById('signup-name').value;
-            const email = document.getElementById('signup-email').value;
-            const password = document.getElementById('signup-password').value;
-            const confirmPassword = document.getElementById('signup-confirm-password').value;
-
-            // Client-side validation
-            if (password !== confirmPassword) {
-                showAlert('danger', 'Passwords do not match.');
-                return;
-            }
-
-            if (password.length < 6) {
-                showAlert('danger', 'Password must be at least 6 characters.');
-                return;
-            }
-
-            try {
-                // Show loading state
-                const submitBtn = signupForm.querySelector('button[type="submit"]');
-                submitBtn.disabled = true;
-                submitBtn.innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Creating account...';
-
-                await handleSignup(name, email, password);
-            } catch (error) {
-                console.error('Signup error:', error);
-                // Error handling is done in handleSignup
-            }
-        });
+    const existingSession = window.ReliefSession?.getCurrentSession?.();
+    if (existingSession?.user) {
+        window.location.href = 'dashboard.html';
+        return;
     }
+
+    signupForm.addEventListener('submit', async function(e) {
+        e.preventDefault();
+
+        const name = document.getElementById('signup-name').value.trim();
+        const email = document.getElementById('signup-email').value.trim().toLowerCase();
+        const password = document.getElementById('signup-password').value;
+        const confirmPassword = document.getElementById('signup-confirm-password').value;
+
+        if (password !== confirmPassword) {
+            showAlert('danger', 'Passwords do not match.');
+            return;
+        }
+
+        if (password.length < 6) {
+            showAlert('danger', 'Password must be at least 6 characters.');
+            return;
+        }
+
+        const submitBtn = signupForm.querySelector('button[type="submit"]');
+        if (submitBtn) {
+            submitBtn.disabled = true;
+            submitBtn.textContent = 'Creating account...';
+        }
+
+        try {
+            const user = await createUser(name, email, password);
+            window.ReliefSession?.createSession?.(user);
+            showAlert('success', 'Account created successfully! Redirecting to dashboard...');
+            setTimeout(() => {
+                window.location.href = 'dashboard.html';
+            }, 800);
+        } catch (error) {
+            showAlert('danger', error.message || 'Signup failed. Please try again.');
+        } finally {
+            if (submitBtn) {
+                submitBtn.disabled = false;
+                submitBtn.textContent = 'Sign Up';
+            }
+        }
+    });
 });
 
-async function handleSignup(name, email, password) {
-    try {
-        // Create user in Firebase Auth
-        const userCredential = await auth.createUserWithEmailAndPassword(email, password);
-
-        // Save additional user data in Firestore
-        await db.collection('users').doc(userCredential.user.uid).set({
-            name,
-            email,
-            createdAt: firebase.firestore.FieldValue.serverTimestamp(),
-            lastLogin: firebase.firestore.FieldValue.serverTimestamp()
-        });
-
-        // Store user in localStorage
-        localStorage.setItem('currentUser', JSON.stringify({
-            id: userCredential.user.uid,
-            email,
-            name
-        }));
-
-        // Show success message
-        showAlert('success', 'Account created successfully! Redirecting...');
-
-        // Redirect after short delay
-        setTimeout(() => {
-            window.location.href = '../index.html';
-        }, 1500);
-
-    } catch (error) {
-        let errorMessage = 'Signup failed. Please try again.';
-
-        // More specific error messages
-        if (error.code === 'auth/email-already-in-use') {
-            errorMessage = 'Email already in use. Please login instead.';
-        } else if (error.code === 'auth/invalid-email') {
-            errorMessage = 'Please enter a valid email address.';
-        } else if (error.code === 'auth/weak-password') {
-            errorMessage = 'Password should be at least 6 characters.';
-        }
-
-        showAlert('danger', errorMessage);
-        console.error('Signup error:', error);
-    } finally {
-        // Reset button state
-        const submitBtn = document.querySelector('#signup-form button[type="submit"]');
-        if (submitBtn) {
-            submitBtn.disabled = false;
-            submitBtn.textContent = 'Sign Up';
+async function createUser(name, email, password) {
+    if (typeof ReliefAPI !== 'undefined' && ReliefAPI.signup) {
+        try {
+            return await ReliefAPI.signup({ name, email, password, joined: new Date().toISOString() });
+        } catch (error) {
+            console.warn('API signup unavailable, falling back to local auth:', error);
         }
     }
+
+    const users = JSON.parse(localStorage.getItem('relief_users') || '[]');
+    if (users.some(item => item.email === email)) {
+        throw new Error('Email already in use. Please login instead.');
+    }
+
+    const localUser = {
+        id: `user_${Date.now()}`,
+        name,
+        email,
+        password,
+        createdAt: new Date().toISOString()
+    };
+
+    users.push(localUser);
+    localStorage.setItem('relief_users', JSON.stringify(users));
+
+    return {
+        uid: localUser.id,
+        email: localUser.email,
+        name: localUser.name
+    };
 }
 
 function showAlert(type, message) {
-    // Remove any existing alerts
     const existingAlert = document.querySelector('.alert');
     if (existingAlert) {
         existingAlert.remove();
@@ -106,7 +98,6 @@ function showAlert(type, message) {
         form.appendChild(alertDiv);
     }
 
-    // Auto-remove after 5 seconds
     setTimeout(() => {
         alertDiv.remove();
     }, 5000);


### PR DESCRIPTION
### Motivation
- Keep users logged in across visits by persisting session tokens and automatically routing authenticated users to the dashboard for a smoother UX.
- Make the auth flow resilient when the remote API is unavailable by adding a local fallback for login/signup and ensure session cleanup on logout.
- Prioritize mobile sessions when multiple valid sessions exist so mobile users get preferred session selection when returning.

### Description
- Added a lightweight session manager (`window.ReliefSession`) in `assets/js/main.js` that creates, stores, touches, prioritizes (mobile-first) and clears tokenized sessions in `localStorage` with a 30-day expiry.
- Updated bootstrapping and auth UI in `assets/js/main.js` to detect active sessions on load, hide/show Login/Sign Up versus Dashboard/Logout, redirect authenticated users off `login.html`/`signup.html` to the dashboard, and wire logout to clear sessions even if the API call fails.
- Reworked `assets/js/login.js` and `assets/js/signup.js` to remove broken ES-module imports, use the API when available, and fall back to a local `relief_users` store for offline/demo auth; both flows now create a persistent session via `ReliefSession` on success and redirect to the dashboard.
- Kept the previously added back-to-top button code and integrated session-driven UI updates so auth and navigation behave consistently across pages.

### Testing
- Ran `node --check assets/js/main.js`, `node --check assets/js/login.js`, and `node --check assets/js/signup.js`, all of which reported no syntax errors.
- Ran `git diff --check` which reported no whitespace or diff issues.
- Started a local static server (`python -m http.server 4174`) for visual verification which launched, and attempted an automated Playwright navigation/screenshot that failed in this environment with `NS_ERROR_NET_RESET`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e9e38703c832d84ea743000fc0d1c)